### PR TITLE
fix: camera permission, EI sensor frequencies, device ID in uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# macOS
+.DS_Store
+**/.DS_Store
+
+# Local Android project directories that live alongside the tracked projects
+# but are not part of this repository.
+EdgeImpulseMobileClientAndroidWrapper/
+EdgeImpulseSwimCollector/
+GATTSensors2/
+ei-zephyr-ble-gatt-client/
+
+# Android build outputs (for any sub-project)
+**/build/
+
+# IDE
+**/.idea/
+*.iml

--- a/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/DataRepository.kt
+++ b/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/DataRepository.kt
@@ -1,6 +1,7 @@
 package com.edgeimpulse.gattsensors
 
 import android.content.Context
+import android.provider.Settings
 import android.util.Log
 import com.google.android.gms.wearable.MessageEvent
 import com.google.gson.Gson
@@ -26,6 +27,10 @@ class DataRepository(private val context: Context, private val apiKeyStore: ApiK
 
     private val client = OkHttpClient()
     private val gson = Gson()
+    private val deviceId: String by lazy {
+        Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            ?: "android-ei-device"
+    }
 
     // For offline logging
     private var isLoggingOffline = false
@@ -96,10 +101,20 @@ class DataRepository(private val context: Context, private val apiKeyStore: ApiK
         isSamplingForRemote = false
     }
 
-    fun uploadCollectedRemoteSample(label: String, hmacKey: String, path: String, sensorName: String) {
-        val sensorInfo = SensorInfo(sensorName, listOf(), 0)
+    fun uploadCollectedRemoteSample(
+        label: String,
+        hmacKey: String,
+        path: String,
+        sensorName: String,
+        intervalMs: Int,
+        lengthMs: Int
+    ) {
+        // Derive frequency and window length from the sample-request parameters.
+        val frequencyHz = if (intervalMs > 0) 1000.0 / intervalMs else 62.5
+        val maxSampleLengthS = (lengthMs / 1000).coerceAtLeast(1)
+        val sensorInfo = SensorInfo(sensorName, listOf(frequencyHz), maxSampleLengthS)
         val values = remoteSampleData.map { it.values.values.toList() }
-        val payload = IngestionPayload("android-device", "ANDROID_PHONE", 10, listOf(sensorInfo), values)
+        val payload = IngestionPayload(deviceId, "ANDROID_PHONE", intervalMs.coerceAtLeast(1), listOf(sensorInfo), values)
         val requestBody = IngestionRequest(Protected("v1", "none", "00"), payload)
 
         val request = Request.Builder()
@@ -218,13 +233,19 @@ class DataRepository(private val context: Context, private val apiKeyStore: ApiK
      * [label] is the EI data label (e.g. "normal", "anomaly").
      */
     fun uploadImage(imageBytes: ByteArray, label: String) {
-        val requestBody = imageBytes.toRequestBody("image/jpeg".toMediaType())
+        val multipart = MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "data",
+                "image_${System.currentTimeMillis()}.jpg",
+                imageBytes.toRequestBody("image/jpeg".toMediaType())
+            )
+            .build()
         val request = Request.Builder()
-            .url("https://ingestion.edgeimpulse.com/api/training/data")
+            .url("https://ingestion.edgeimpulse.com/api/training/files")
             .header("x-api-key", apiKeyStore.get())
             .header("x-label", label)
-            .header("Content-Type", "image/jpeg")
-            .post(requestBody)
+            .post(multipart)
             .build()
 
         CoroutineScope(Dispatchers.IO).launch {

--- a/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/EdgeImpulseManager.kt
+++ b/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/EdgeImpulseManager.kt
@@ -4,6 +4,11 @@ import android.util.Log
 import com.google.gson.Gson
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import okhttp3.*
 import okhttp3.logging.HttpLoggingInterceptor
@@ -29,14 +34,25 @@ data class HelloResponse(val hello: Boolean, val err: String?)
 data class SampleRequest(val sample: SampleRequestMessage)
 data class SampleRequestMessage(val label: String, val length: Int, val path: String, val hmacKey: String, val interval: Int, val sensor: String)
 
-class EdgeImpulseManager(private val apiKeyStore: ApiKeyStore, private val repository: DataRepository) {
+class EdgeImpulseManager(
+    private val apiKeyStore: ApiKeyStore,
+    private val repository: DataRepository,
+    private val deviceId: String
+) {
 
     private val client: OkHttpClient
     private var webSocket: WebSocket? = null
     private val gson = Gson()
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
 
-    private val deviceId = "android-device"
+    private val _isConnected = MutableStateFlow(false)
+    val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+
+    private val _connectionError = MutableStateFlow("")
+    val connectionError: StateFlow<String> = _connectionError.asStateFlow()
+
+    @Volatile private var shouldReconnect = true
+    private var reconnectJob: Job? = null
 
     init {
         val logging = HttpLoggingInterceptor().apply {
@@ -49,10 +65,16 @@ class EdgeImpulseManager(private val apiKeyStore: ApiKeyStore, private val repos
     }
 
     fun connect() {
+        shouldReconnect = true
+        openSocket()
+    }
+
+    private fun openSocket() {
         val request = Request.Builder().url("wss://remote-mgmt.edgeimpulse.com").build()
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
             override fun onOpen(webSocket: WebSocket, response: Response) {
                 Log.d("EdgeImpulseManager", "WebSocket opened")
+                _connectionError.value = ""
                 sendHello()
             }
 
@@ -63,25 +85,46 @@ class EdgeImpulseManager(private val apiKeyStore: ApiKeyStore, private val repos
 
             override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
                 webSocket.close(1000, null)
+                _isConnected.value = false
                 Log.d("EdgeImpulseManager", "WebSocket closing: $code / $reason")
+                if (shouldReconnect) scheduleReconnect()
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                _isConnected.value = false
+                _connectionError.value = t.message ?: "Connection failed"
                 Log.e("EdgeImpulseManager", "WebSocket failure: ${t.message}")
+                if (shouldReconnect) scheduleReconnect()
             }
         })
     }
 
+    fun reconnect() {
+        reconnectJob?.cancel()
+        webSocket?.cancel()
+        _isConnected.value = false
+        openSocket()
+    }
+
+    private fun scheduleReconnect() {
+        reconnectJob?.cancel()
+        reconnectJob = coroutineScope.launch {
+            delay(5_000)
+            if (shouldReconnect) {
+                Log.d("EdgeImpulseManager", "Reconnecting…")
+                openSocket()
+            }
+        }
+    }
+
     private fun sendHello() {
+        // Only advertise sensors that have a fixed sampling frequency.
+        // Sensors without frequencies (camera, GPS) cause a server-side
+        // "sensor frequencies has length of zero" validation error.
         val sensors = listOf(
-            SensorInfo("Accelerometer", listOf(100, 62.5), 600),
-            SensorInfo("PPG (Heart Rate)", listOf(), 600),
-            SensorInfo("GPS", listOf(), 600),
-            SensorInfo("Camera", listOf(), 60000),
-            SensorInfo("EEG", listOf(), 600),
-            SensorInfo("ECG", listOf(), 600)
+            SensorInfo("Accelerometer", listOf(62.5, 100), 600)
         )
-        val hello = Hello(HelloMessage(3, apiKeyStore.get(), deviceId, "ANDROID_PHONE", "daemon", sensors, true))
+        val hello = Hello(HelloMessage(3, apiKeyStore.get(), deviceId, "ANDROID_PHONE", "ip", sensors, true))
         webSocket?.send(gson.toJson(hello))
     }
 
@@ -89,8 +132,12 @@ class EdgeImpulseManager(private val apiKeyStore: ApiKeyStore, private val repos
         try {
             val helloResponse = gson.fromJson(text, HelloResponse::class.java)
             if (helloResponse.hello) {
-                Log.d("EdgeImpulseManager", "Hello successful")
-            } else {
+                _isConnected.value = true
+                _connectionError.value = ""
+                Log.d("EdgeImpulseManager", "Hello successful — device registered")
+            } else if (helloResponse.err != null) {
+                _isConnected.value = false
+                _connectionError.value = helloResponse.err
                 Log.e("EdgeImpulseManager", "Hello failed: ${helloResponse.err}")
             }
         } catch (e: Exception) { /* Not a hello response */ }
@@ -110,10 +157,12 @@ class EdgeImpulseManager(private val apiKeyStore: ApiKeyStore, private val repos
                         // Notify that we are uploading
                         webSocket?.send("{\"sampleUploading\": true}")
                         repository.uploadCollectedRemoteSample(
-                            sample.label,
-                            sample.hmacKey,
-                            sample.path,
-                            sensorName = "Accelerometer"
+                            label       = sample.label,
+                            hmacKey     = sample.hmacKey,
+                            path        = sample.path,
+                            sensorName  = "Accelerometer",
+                            intervalMs  = sample.interval,
+                            lengthMs    = sample.length
                         )
                         // Notify that we are finished
                         webSocket?.send("{\"sampleFinished\": true}")
@@ -126,6 +175,9 @@ class EdgeImpulseManager(private val apiKeyStore: ApiKeyStore, private val repos
     }
 
     fun disconnect() {
+        shouldReconnect = false
+        reconnectJob?.cancel()
+        _isConnected.value = false
         webSocket?.close(1000, "Client disconnect")
     }
 }

--- a/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/MainActivity.kt
+++ b/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/MainActivity.kt
@@ -28,7 +28,15 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings as AndroidSettings
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -184,8 +192,11 @@ fun AppRoot(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
-    val sensorData by viewModel.sensorData.collectAsState()
-    var isRunning  by remember { mutableStateOf(false) }
+    val sensorData  by viewModel.sensorData.collectAsState()
+    val isRunning   by viewModel.isCollecting.collectAsState()
+    val eiConnected by viewModel.eiConnected.collectAsState()
+    val eiError     by viewModel.eiConnectionError.collectAsState()
+
     var label      by remember { mutableStateOf("") }
     var offlineOn  by remember { mutableStateOf(false) }
     var statusMsg  by remember { mutableStateOf("") }
@@ -194,6 +205,13 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
     var dropdownOpen   by remember { mutableStateOf(false) }
     var selectedSensor by remember { mutableStateOf(sensorOptions[0]) }
 
+    // Duration state
+    val durationPresets = listOf(1, 2, 10, 20)
+    var sliderValue      by remember { mutableFloatStateOf(2f) }
+    var customDuration   by remember { mutableStateOf("") }  // for > 100 s
+    val effectiveDurationSec: Int = customDuration.toIntOrNull()?.takeIf { it > 0 }
+        ?: sliderValue.toInt().coerceAtLeast(1)
+
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -201,7 +219,43 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
         verticalArrangement = Arrangement.spacedBy(12.dp),
         contentPadding = PaddingValues(vertical = 16.dp)
     ) {
-        // ── Section: Sensor picker ──────────────────────────────────────────
+        // ── EI remote-management connection banner ──────────────────────────
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        if (eiConnected) Color(0xFF1B5E20) else Color(0xFF37474F),
+                        shape = MaterialTheme.shapes.medium
+                    )
+                    .padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        if (eiConnected) "Connected to Edge Impulse Studio"
+                        else "Not connected to Edge Impulse",
+                        color = Color.White,
+                        fontWeight = FontWeight.SemiBold,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    if (!eiConnected && eiError.isNotBlank()) {
+                        Text(eiError, color = Color.White.copy(alpha = 0.7f),
+                            style = MaterialTheme.typography.labelSmall)
+                    }
+                }
+                if (!eiConnected) {
+                    TextButton(onClick = { viewModel.reconnectEI() }) {
+                        Text("Retry", color = MaterialTheme.colorScheme.primary)
+                    }
+                } else {
+                    Icon(Icons.Default.CloudDone, contentDescription = null, tint = Color.White)
+                }
+            }
+        }
+
+        // ── Section: Sensor picker ─────────────────────────────────────────
         item {
             Text("Data source", style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary)
@@ -229,7 +283,7 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
             }
         }
 
-        // ── Section: Label ─────────────────────────────────────────────────
+        // ── Section: Label ──────────────────────────────────────────────────
         item {
             OutlinedTextField(
                 value         = label,
@@ -241,8 +295,68 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
             )
         }
 
-        // ── Section: Collection controls ───────────────────────────────────
+        // ── Section: Duration ───────────────────────────────────────────────
         item {
+            HorizontalDivider()
+            Text("Sample duration", style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary)
+        }
+        item {
+            // Quick-pick chips
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                durationPresets.forEach { sec ->
+                    FilterChip(
+                        selected = customDuration.isEmpty() && sliderValue.toInt() == sec,
+                        onClick  = { sliderValue = sec.toFloat(); customDuration = "" },
+                        label    = { Text("${sec}s") }
+                    )
+                }
+            }
+        }
+        item {
+            // Slider 1–100 s
+            Column {
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        if (customDuration.isNotBlank()) "Custom: ${customDuration}s"
+                        else "${sliderValue.toInt()} s",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Text("1 – 100 s", style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Slider(
+                    value         = sliderValue,
+                    onValueChange = { sliderValue = it; customDuration = "" },
+                    valueRange    = 1f..100f,
+                    steps         = 98,
+                    modifier      = Modifier.fillMaxWidth()
+                )
+            }
+        }
+        item {
+            // Extended duration (> 100 s)
+            OutlinedTextField(
+                value         = customDuration,
+                onValueChange = { customDuration = it },
+                label         = { Text("Custom duration (s)") },
+                placeholder   = { Text("Enter any value > 100") },
+                singleLine    = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier      = Modifier.fillMaxWidth(),
+                trailingIcon  = { Text("s", modifier = Modifier.padding(end = 12.dp)) }
+            )
+        }
+
+        // ── Section: Collection controls ────────────────────────────────────────
+        item {
+            HorizontalDivider()
             Text("Collection", style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary)
         }
@@ -250,17 +364,19 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     modifier = Modifier.weight(1f),
-                    enabled  = !isRunning,
+                    enabled  = !isRunning && label.isNotBlank(),
                     onClick  = {
-                        viewModel.startSensor(selectedSensor)
                         if (offlineOn) viewModel.startOfflineLogging()
-                        isRunning = true
-                        statusMsg = "Collecting $selectedSensor…"
+                        viewModel.startSensorForDuration(
+                            selectedSensor,
+                            effectiveDurationSec * 1000L
+                        )
+                        statusMsg = "Collecting ${selectedSensor} for ${effectiveDurationSec}s…"
                     }
                 ) {
                     Icon(Icons.Default.PlayArrow, contentDescription = null)
                     Spacer(Modifier.width(4.dp))
-                    Text("Start")
+                    Text("Start (${effectiveDurationSec}s)")
                 }
                 Button(
                     modifier = Modifier.weight(1f),
@@ -271,7 +387,6 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
                     onClick  = {
                         viewModel.stopSensor()
                         if (offlineOn) viewModel.stopOfflineLogging()
-                        isRunning = false
                         statusMsg = "Stopped."
                     }
                 ) {
@@ -282,7 +397,7 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
             }
         }
 
-        // ── Section: Offline CSV toggle + upload ───────────────────────────
+        // ── Section: Offline CSV toggle + upload ───────────────────────────────
         item {
             HorizontalDivider()
             Text("Offline logging", style = MaterialTheme.typography.labelLarge,
@@ -301,7 +416,7 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
                 enabled  = label.isNotBlank(),
                 onClick  = {
                     viewModel.uploadStoredCsvFiles(label)
-                    statusMsg = "Uploading CSV files with label '$label'…"
+                    statusMsg = "Uploading CSV files with label ‘$label’…"
                 }
             ) {
                 Icon(Icons.Default.Upload, contentDescription = null)
@@ -318,45 +433,100 @@ fun CollectScreen(viewModel: SensorViewModel, cameraHelper: CameraHelper) {
         }
         item {
             val context = LocalContext.current
-            var hasCameraPermission by remember {
-                mutableStateOf(
-                    ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
-                        == PackageManager.PERMISSION_GRANTED
-                )
+            val activity = context as android.app.Activity
+            val lifecycleOwner = LocalLifecycleOwner.current
+
+            fun hasCamPerm() = ContextCompat.checkSelfPermission(
+                context, Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+
+            var hasCameraPermission by remember { mutableStateOf(hasCamPerm()) }
+
+            // Re-check on every resume so the UI reflects changes made in system Settings.
+            DisposableEffect(lifecycleOwner) {
+                val observer = LifecycleEventObserver { _, event ->
+                    if (event == Lifecycle.Event.ON_RESUME) {
+                        val nowGranted = hasCamPerm()
+                        hasCameraPermission = nowGranted
+                        if (nowGranted) cameraHelper.bindToLifecycle(lifecycleOwner)
+                    }
+                }
+                lifecycleOwner.lifecycle.addObserver(observer)
+                onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
             }
+
             val cameraPermissionLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
                 androidx.activity.result.contract.ActivityResultContracts.RequestPermission()
             ) { granted ->
                 hasCameraPermission = granted
                 if (granted) {
-                    viewModel.captureAndUploadImage(cameraHelper, label)
-                    statusMsg = "Capturing image…"
+                    cameraHelper.bindToLifecycle(lifecycleOwner)
                 } else {
-                    statusMsg = "Camera permission denied — grant it in Settings"
+                    statusMsg = if (!activity.shouldShowRequestPermissionRationale(Manifest.permission.CAMERA))
+                        "Permission permanently denied \u2014 tap \"Open Settings\" below"
+                    else
+                        "Camera permission denied"
                 }
             }
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                enabled  = label.isNotBlank(),
-                onClick  = {
-                    if (hasCameraPermission) {
-                        viewModel.captureAndUploadImage(cameraHelper, label)
-                        statusMsg = "Capturing image…"
-                    } else {
-                        cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+
+            // If the system will never show the dialog again, send the user to Settings.
+            val permanentlyDenied = !hasCameraPermission &&
+                !activity.shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (!hasCameraPermission) {
+                    // Grant / open-settings button \u2014 always enabled, no label needed
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = {
+                            if (permanentlyDenied) {
+                                context.startActivity(
+                                    Intent(AndroidSettings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                        data = Uri.fromParts("package", context.packageName, null)
+                                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                    }
+                                )
+                            } else {
+                                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+                            }
+                        }
+                    ) {
+                        Icon(Icons.Default.NoPhotography, contentDescription = null)
+                        Spacer(Modifier.width(6.dp))
+                        Text(if (permanentlyDenied) "Open Settings to grant camera" else "Grant camera permission")
                     }
                 }
-            ) {
-                Icon(
-                    if (hasCameraPermission) Icons.Default.CameraAlt else Icons.Default.NoPhotography,
-                    contentDescription = null
-                )
-                Spacer(Modifier.width(6.dp))
-                Text(if (hasCameraPermission) "Capture & upload image" else "Grant camera & capture")
+                // Capture button \u2014 only usable once permission is granted and a label is set
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled  = hasCameraPermission && label.isNotBlank(),
+                    onClick  = {
+                        viewModel.captureAndUploadImage(cameraHelper, label)
+                        statusMsg = "Capturing image\u2026"
+                    }
+                ) {
+                    Icon(Icons.Default.CameraAlt, contentDescription = null)
+                    Spacer(Modifier.width(6.dp))
+                    Text("Capture & upload image")
+                }
+                when {
+                    !hasCameraPermission -> Text(
+                        if (permanentlyDenied)
+                            "Camera access was permanently denied. Open Settings and enable the Camera permission."
+                        else
+                            "Grant camera permission to capture images.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    label.isBlank() -> Text(
+                        "Enter a label above to enable capture.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
-
-        // ── Section: Live readout ───────────────────────────────────────────
+        // ── Section: Live readout ─────────────────────────────────────────────
         if (sensorData != null) {
             item {
                 HorizontalDivider()

--- a/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/SensorViewModel.kt
+++ b/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/SensorViewModel.kt
@@ -3,6 +3,8 @@ package com.edgeimpulse.gattsensors
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -19,6 +21,13 @@ class SensorViewModel(
 
     private val _sensorData = MutableStateFlow<SensorData?>(null)
     val sensorData = _sensorData.asStateFlow()
+
+    private val _isCollecting = MutableStateFlow(false)
+    val isCollecting = _isCollecting.asStateFlow()
+
+    /** EI remote-management connection state (set by EdgeImpulseManager). */
+    val eiConnected     = edgeImpulseManager.isConnected
+    val eiConnectionError = edgeImpulseManager.connectionError
 
     private val speechRecognitionHelper = SpeechRecognitionHelper(application)
     val recognizedText = speechRecognitionHelper.recognizedText
@@ -37,15 +46,35 @@ class SensorViewModel(
         edgeImpulseManager.connect()
     }
 
+    private var durationJob: Job? = null
+
     fun startSensor(sensorType: String = "Accelerometer") {
+        _isCollecting.value = true
         gattServerManager.startServer()
         sensorCollector.start(sensorType)
     }
 
+    /** Start collecting for exactly [durationMs] ms, then auto-stop. */
+    fun startSensorForDuration(sensorType: String, durationMs: Long) {
+        if (_isCollecting.value) return
+        _isCollecting.value = true
+        gattServerManager.startServer()
+        sensorCollector.start(sensorType)
+        durationJob = viewModelScope.launch {
+            delay(durationMs)
+            stopSensor()
+        }
+    }
+
     fun stopSensor() {
+        durationJob?.cancel()
+        durationJob = null
         sensorCollector.stop()
         gattServerManager.stopServer()
+        _isCollecting.value = false
     }
+
+    fun reconnectEI() = edgeImpulseManager.reconnect()
 
     fun startListening() {
         speechRecognitionHelper.startListening()

--- a/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/ViewModelFactory.kt
+++ b/android-data-collector/app/src/main/java/com/edgeimpulse/gattsensors/ViewModelFactory.kt
@@ -3,6 +3,7 @@ package com.edgeimpulse.gattsensors
 import android.app.Application
 import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.provider.Settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 
@@ -13,10 +14,13 @@ class ViewModelFactory(private val application: Application) : ViewModelProvider
                 application.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
             val bluetoothAdapter = bluetoothManager.adapter
             val apiKeyStore         = ApiKeyStore(application)
+            val deviceId            = Settings.Secure.getString(
+                application.contentResolver, Settings.Secure.ANDROID_ID
+            ) ?: "android-ei-device"
             val dataRepository      = DataRepository(application, apiKeyStore)
             val gattServerManager   = GattServerManager(application, bluetoothAdapter)
             val collector           = SensorCollector(application, dataRepository, gattServerManager)
-            val edgeImpulseManager  = EdgeImpulseManager(apiKeyStore, dataRepository)
+            val edgeImpulseManager  = EdgeImpulseManager(apiKeyStore, dataRepository, deviceId)
             val zephyrBLEClient     = ZephyrBLEClient(application, dataRepository)
             @Suppress("UNCHECKED_CAST")
             return SensorViewModel(

--- a/android-data-collector/gradle.properties
+++ b/android-data-collector/gradle.properties
@@ -1,4 +1,4 @@
-EI_API_KEY=ei_CHANGE_ME
+EI_API_KEY=ei_4CHANGEME
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx4g


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Android data collector app, focusing on enhanced device identification, more robust Edge Impulse Studio connectivity, and a significantly improved data collection UI with flexible sample duration controls. The changes are grouped into backend improvements, connectivity enhancements, and UI/UX upgrades.

**Backend and Data Handling Improvements:**

* The app now uses a unique device ID (`ANDROID_ID`) for identifying the device in ingestion payloads, replacing the previous hardcoded value. This ensures more accurate device tracking in Edge Impulse Studio. [[1]](diffhunk://#diff-d8ee580cd1ccba5431d89bc9855f50a022208a1ba15aaf7aeacc09dc35e217f2R4) [[2]](diffhunk://#diff-d8ee580cd1ccba5431d89bc9855f50a022208a1ba15aaf7aeacc09dc35e217f2R30-R33) [[3]](diffhunk://#diff-d8ee580cd1ccba5431d89bc9855f50a022208a1ba15aaf7aeacc09dc35e217f2L99-R117)
* The ingestion payload for remote sample uploads now includes actual sampling frequency and sample duration, derived from user input, improving data integrity. [[1]](diffhunk://#diff-d8ee580cd1ccba5431d89bc9855f50a022208a1ba15aaf7aeacc09dc35e217f2L99-R117) [[2]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afL113-R165)
* Image uploads now use a multipart request and a new endpoint (`/api/training/files`), aligning with updated ingestion APIs.

**Edge Impulse Connectivity Enhancements:**

* The `EdgeImpulseManager` now exposes connection state and error messages via `StateFlow`, enabling real-time UI updates on connection status. [[1]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afL32-R55) [[2]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afR88-R140)
* Implements automatic reconnection logic and a manual "Retry" option, improving reliability when connecting to Edge Impulse Studio. [[1]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afR68-R77) [[2]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afR88-R140) [[3]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afR178-R180)
* Only sensors with fixed sampling frequencies are advertised to avoid server-side validation errors. (F6b8751fL85R110)

**UI/UX Upgrades in Data Collection:**

* Adds a prominent connection status banner to the data collection screen, displaying real-time connection state and errors, with a "Retry" button if disconnected. [[1]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L188-R199) [[2]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8R208-R258)
* Introduces flexible sample duration controls: users can select from presets, use a slider for 1–100 seconds, or enter custom durations over 100 seconds. The chosen duration is used for sensor collection and reflected in the UI. [[1]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8R208-R258) [[2]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L244-R379)
* Updates collection controls to require a label before starting, disables the start button while collecting, and displays the selected duration in the start button. [[1]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L188-R199) [[2]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L244-R379)
* Minor UI polish, such as improved status messages and more consistent section dividers.

These changes collectively make the app more robust, user-friendly, and better integrated with Edge Impulse Studio.

**References:**  
[[1]](diffhunk://#diff-d8ee580cd1ccba5431d89bc9855f50a022208a1ba15aaf7aeacc09dc35e217f2R4) [[2]](diffhunk://#diff-d8ee580cd1ccba5431d89bc9855f50a022208a1ba15aaf7aeacc09dc35e217f2R30-R33) [[3]](diffhunk://#diff-d8ee580cd1ccba5431d89bc9855f50a022208a1ba15aaf7aeacc09dc35e217f2L99-R117) [[4]](diffhunk://#diff-d8ee580cd1ccba5431d89bc9855f50a022208a1ba15aaf7aeacc09dc35e217f2L221-R248) [[5]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afR7-R11) [[6]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afL32-R55) [[7]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afR68-R77) [[8]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afR88-R140) F6b8751fL85R110, [[9]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afL113-R165) [[10]](diffhunk://#diff-e4469e2d9e406385ac73ad992c8aea1d0d8953e63f0ea0c752880956916135afR178-R180) [[11]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8R31-R39) [[12]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L188-R199) [[13]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8R208-R258) [[14]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L232-R286) [[15]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L244-R379) [[16]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L274) [[17]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L285-R400) [[18]](diffhunk://#diff-de5c9ef55ebe7f1a58d9ff4f3263585301476165beb49813f905ecfd6bbd34c8L304-R419)